### PR TITLE
PENDING windows cannot support bind propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ echo "hello localstackmount" > hello.txt
 cat hello.txt
 ```
 
+## docker compose
+
+WIP 
+
+```sh
+docker compose up -d
+docker exec -it localstackmount-mount-1 bash
+cd ~/mount/localstack/
+ls
+# <your buckets>
+```
+
 
 ## Limitations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 
 services:
   localstack:
@@ -40,12 +40,13 @@ services:
     security_opt:
       - apparmor:unconfined
     volumes:
-#      - ./mount:/root/mount/localstack:ro
       # https://matsuand.github.io/docs.docker.jp.onthefly/compose/compose-file/compose-file-v3/#volumes
+      # https://docs.docker.com/compose/compose-file/compose-file-v3/#long-syntax-3
       - type: bind
-        source: ./mount
+        source: mount
         target: /root/mount
         bind:
+          # https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation
           propagation: rshared
     depends_on:
       localstack:


### PR DESCRIPTION
Windowsではcontainer mountのpropagationはサポートしていない模様。

> マウント ポイントでバインド伝播を設定するには、ホスト ファイルシステムが既にバインド伝播をサポートしている必要があります。

https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation